### PR TITLE
Fix all implicit casts to make C++ compilers happy

### DIFF
--- a/src/fpconv.c
+++ b/src/fpconv.c
@@ -124,7 +124,7 @@ double fpconv_strtod(const char *nptr, char **endptr)
     /* Duplicate number into buffer */
     if (buflen >= FPCONV_G_FMT_BUFSIZE) {
         /* Handle unusually large numbers */
-        buf = malloc(buflen + 1);
+        buf = (char *)malloc(buflen + 1);
         if (!buf) {
             fprintf(stderr, "Out of memory");
             abort();

--- a/src/lua_cjson.c
+++ b/src/lua_cjson.c
@@ -195,7 +195,7 @@ static json_config_t *json_fetch_config(lua_State *l)
 {
     json_config_t *cfg;
 
-    cfg = lua_touserdata(l, lua_upvalueindex(1));
+    cfg = (json_config_t *)lua_touserdata(l, lua_upvalueindex(1));
     if (!cfg)
         luaL_error(l, "BUG: Unable to fetch CJSON configuration");
 
@@ -362,7 +362,7 @@ static int json_destroy_config(lua_State *l)
 {
     json_config_t *cfg;
 
-    cfg = lua_touserdata(l, 1);
+    cfg = (json_config_t *)lua_touserdata(l, 1);
     if (cfg)
         strbuf_free(&cfg->encode_buf);
     cfg = NULL;
@@ -375,7 +375,7 @@ static void json_create_config(lua_State *l)
     json_config_t *cfg;
     int i;
 
-    cfg = lua_newuserdata(l, sizeof(*cfg));
+    cfg = (json_config_t *)lua_newuserdata(l, sizeof(*cfg));
 
     /* Create GC method to clean up strbuf */
     lua_newtable(l);

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -58,7 +58,7 @@ void strbuf_init(strbuf_t *s, int len)
     s->reallocs = 0;
     s->debug = 0;
 
-    s->buf = malloc(size);
+    s->buf = (char *)malloc(size);
     if (!s->buf)
         die("Out of memory");
 
@@ -69,7 +69,7 @@ strbuf_t *strbuf_new(int len)
 {
     strbuf_t *s;
 
-    s = malloc(sizeof(strbuf_t));
+    s = (strbuf_t *)malloc(sizeof(strbuf_t));
     if (!s)
         die("Out of memory");
 
@@ -173,7 +173,7 @@ void strbuf_resize(strbuf_t *s, int len)
     }
 
     s->size = newsize;
-    s->buf = realloc(s->buf, s->size);
+    s->buf = (char *)realloc(s->buf, s->size);
     if (!s->buf)
         die("Out of memory");
     s->reallocs++;


### PR DESCRIPTION
There are some implicit casts which do not meet the C++ standard.
In gcc and llvm clang, we can use `-fpermissive` to make all these errors to warnings so the compile process do not fail, but apple clang just ignore `-fpermissive`.
We need fix these implicit casts if we want to compile kvrocks by apple clang. 😢 